### PR TITLE
disable underlined on hover hoofdmenu broken

### DIFF
--- a/oefening08-dropdownmenu/css/dropdown.css
+++ b/oefening08-dropdownmenu/css/dropdown.css
@@ -79,7 +79,7 @@ de kleuren van het item wijzigen */
 
 /* grijze achtergrondkleur toevoegen en onderstreping verwijderen
 bij het hoveren over een hoofdmenu-item. */
-.dropdown-menu > li:hover {
+.dropdown-menu > li:hover > a {
   background-color: #ddd;
   text-decoration: none;
 }


### PR DESCRIPTION
de text-decoration in de oplossing werkt niet doordat het link element niet meegeven werd